### PR TITLE
Fix erase error

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,5 +281,5 @@ function downloadSurveys(askUser = true) {
 
 /** Erases all surveys from `localStorage` after prompting the user */
 function eraseSurveys() {
-  if (prompt("Type 'erase' to erase saved surveys") == "erase") localStorage.surveys = "";
+  if (prompt("Type 'erase' to erase saved surveys") == "erase") localStorage.surveys = "[]";
 }


### PR DESCRIPTION
Upon erasing surveys, localStorage.surveys is set to "". This directly conflicts with how surveys are saved. Looking at line 218 in index.js, localStorage.surveys will be used as long as it is not null or undefined. "" is neither of these, so it uses "" instead of "[]", causing invalid JSON errors. By setting localStorage.surveys to "[]" upon erasure instead of "", we can avoid this problem.